### PR TITLE
Optional palette query - Tested

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ app.listen(app.get('port'), () => {
 
 app.get('/api/v1/projects', (req, res) => {
   const { palettes } = req.query;
-  
+
   if (palettes === 'included') {
     database('palettes')
     .join('projects', 'projects.id', '=', 'palettes.project_id')
@@ -78,17 +78,9 @@ app.post('/api/v1/projects', (req, res) => {
     });
   }
 
-  database('projects')
-  .where({ name })
-  .then(project => {
-    if (!!project.length) {
-      res.status(409).json({ error: 'Project name already exists' })
-    } else {
-      database('projects').insert({ name }, 'id')
-      .then(projectId => res.status(201).json(projectId))
-      .catch(error => res.status(500).json({ error }))
-    }
-  }).catch(error => res.status(500).json({ error }))
+  database('projects').insert({ name }, 'id')
+  .then(projectId => res.status(201).json(projectId))
+  .catch(error => res.status(500).json({ error }))
 });
 
 app.post('/api/v1/palettes', (req, res) => {

--- a/server.js
+++ b/server.js
@@ -9,19 +9,20 @@ const cors = require('cors');
 app.use(bodyParser.json());
 
 app.use(cors());
-app.set('port', process.env.PORT || 30001);
+app.set('port', process.env.PORT || 3001);
 
 app.listen(app.get('port'), () => {
   console.log(`App is running in port ${app.get('port')}`)
 });
 
-app.get('/api/v1/projects/:with_palettes?', (req, res) => {
-  const { with_palettes } = req.params;
-
-  if (!!with_palettes) {
+app.get('/api/v1/projects', (req, res) => {
+  const { palettes } = req.query;
+  
+  if (palettes === 'included') {
     database('palettes')
     .join('projects', 'projects.id', '=', 'palettes.project_id')
     .then(projects => res.status(200).json(projects))
+    .catch(error => res.status(500).json({ error }))
   } else {
     database('projects')
     .select()

--- a/server.spec.js
+++ b/server.spec.js
@@ -25,7 +25,18 @@ describe('Server', () => {
 			const result = response.body;
 
 			expect(result).toEqual(expectedProjects);
-		});
+    });
+    
+    it('should projects with palettes included if query string is set to included', async () => {
+
+      const response = await request(app)
+        .get('/api/v1/projects?palettes=included');
+      const result = response.body[0];
+
+      expect(result).toHaveProperty('color_1');
+			expect(result).toHaveProperty('color_3');
+			expect(result).toHaveProperty('color_5');      
+    })
 	});
 
 	describe('GET /api/v1/projects/:id', () => {


### PR DESCRIPTION
Added an optional query param for project get requests, Heres how it works:
-> If you go to path "/api/v1/projects/?palettes=included" it will trigger a condition in the normal get method and join the palettes and projects table and that is what gets returned
-> The normal get path works the same way and would just return the list of project names
closes #23 
I also removed that extra 0  on our default port 😂