### PR TITLE
Add default project seed and query for getting all palettes for a cer…

### DIFF
--- a/db/seeds/dev/dummy-palettes.js
+++ b/db/seeds/dev/dummy-palettes.js
@@ -30,6 +30,7 @@ exports.seed = function(knex) {
     })
     .then(() => {
       const promises = [];
+      promises.push(addProject(knex, { name: 'Uncategorized', palettes: [] }))
       dummyData.forEach(project => promises.push(addProject(knex, project)))
       return Promise.all(promises)
     })

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ const cors = require('cors');
 app.use(bodyParser.json());
 
 app.use(cors());
-app.set('port', process.env.PORT || 3001);
+app.set('port', process.env.PORT || 3005);
 
 app.listen(app.get('port'), () => {
   console.log(`App is running in port ${app.get('port')}`)
@@ -20,14 +20,14 @@ app.get('/api/v1/projects', (req, res) => {
 
   if (palettes === 'included') {
     database('palettes')
-    .join('projects', 'projects.id', '=', 'palettes.project_id')
-    .then(projects => res.status(200).json(projects))
-    .catch(error => res.status(500).json({ error }))
+      .join('projects', 'projects.id', '=', 'palettes.project_id')
+      .then(projects => res.status(200).json(projects))
+      .catch(error => res.status(500).json({ error }))
   } else {
     database('projects')
-    .select()
-    .then(projects => res.status(200).json(projects))
-    .catch(error => res.status(500).json({ error }))
+      .select()
+      .then(projects => res.status(200).json(projects))
+      .catch(error => res.status(500).json({ error }))
   }
 });
 
@@ -48,10 +48,19 @@ app.get('/api/v1/projects/:id', (req, res) => {
 })
 
 app.get('/api/v1/palettes', (req, res) => {
-  database('palettes')
-  .select()
-    .then(palettes => res.status(200).json(palettes))
-  .catch(error => res.status(500).json({ error }))
+  const { project_id } = req.query;
+
+  if (project_id) {
+    database('palettes')
+      .where({ project_id })
+      .then(palettes => res.status(200).json(palettes))
+      .catch(error => res.status(500).json({ error }))
+  } else {
+    database('palettes')
+      .select()
+      .then(palettes => res.status(200).json(palettes))
+      .catch(error => res.status(500).json({ error }))
+  }
 });
 
 app.get('/api/v1/palettes/:id', (req, res) => {


### PR DESCRIPTION
…tain project ID.

I added to our seed file a default project called "Uncategorized", and also added another query to the palettes endpoint that lets us query all palettes for a certain project. 

I'm trying to decide whether it's better to fetch all project and palette data and stitch it together, or better to fetch projects and then loop through and use the new query to get palette data for each.  E.g. is more querying always worse?  We're getting the exact same amount of data in the end either way, so not sure which method would be less expensive.  Would love your thoughts!