### PR TITLE
Update join query to prevent id conflicts 

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,10 +19,9 @@ app.get('/api/v1/projects', (req, res) => {
   const { palettes } = req.query;
 
   if (palettes === 'included') {
-    database('palettes')
-      .join('projects', 'projects.id', '=', 'palettes.project_id')
-      .then(projects => res.status(200).json(projects))
-      .catch(error => res.status(500).json({ error }))
+    database.raw('SELECT proj.project_name, proj.id AS project_id, pal.palette_name, pal.id AS palette_id, pal.color_1, pal.color_2, pal.color_3, pal.color_4, pal.color_5 FROM palettes AS pal LEFT JOIN projects AS proj ON pal.project_id = proj.id ORDER BY proj.id')
+    .then(projects => res.status(200).json(projects.rows))
+    .catch(error => res.status(500).json({ error }))
   } else {
     database('projects')
       .select()


### PR DESCRIPTION
This is the new format it comes in

```
[
    {
        "project_name": "project0",
        "project_id": 2,
        "palette_name": "palette0",
        "palette_id": 2,
        "color_1": "#433047",
        "color_2": "#967578",
        "color_3": "#333547",
        "color_4": "#798776",
        "color_5": "#839967"
    },
    {
        "project_name": "project0",
        "project_id": 2,
        "palette_name": "palette0",
        "palette_id": 1,
        "color_1": "#488047",
        "color_2": "#925578",
        "color_3": "#319547",
        "color_4": "#796876",
        "color_5": "#834267"
    },
...............
]
```